### PR TITLE
Update helm charts for 11.4.  Adds the ability to specify annotations…

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -9,3 +9,9 @@ helm install -f overrides_example.yaml estap ./estap
 
 Uninstall can be performed by...
 helm delete estap ./estap
+
+Upgrade can be performed by...
+helm upgrade estap ./estap
+
+Certificates can be regenerated (while keeping the same CA) with...
+helm upgrade --set updateSecret=true estap ./estap

--- a/charts/estap/templates/_helpers.tpl
+++ b/charts/estap/templates/_helpers.tpl
@@ -118,7 +118,7 @@ readOnlyRootFilesystem: true
 {{- end }}
 
 {{- define "estap-deploy.estap.proxy.proxy_protocol" }}
-{{- if .Values.estap.proxy }}{{- if .Values.estap.proxy.proxy_protocol }}1{{- else }}0{{- end }}{{- else }}0{{- end }}
+{{- if .Values.estap.proxy }}{{ .Values.estap.proxy.proxy_protocol | default 0 }}{{- else }}0{{- end }}
 {{- end }}
 
 {{- define "estap-deploy.estap.proxy.disconnect_on_invalid_certificate" }}

--- a/charts/estap/templates/default-networkpolicy.yaml
+++ b/charts/estap/templates/default-networkpolicy.yaml
@@ -1,0 +1,17 @@
+# vim: ts=2:sw=2:et
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "common.name" . }}-deny-all
+  labels:
+    component: {{ include "common.name" . }}
+    app: {{ include "common.name" . }}
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  ingress: []
+  egress: []
+  podSelector:
+    matchLabels:
+      component: {{ include "common.name" . }}
+      tier: backend

--- a/charts/estap/templates/estap-configmap.yaml
+++ b/charts/estap/templates/estap-configmap.yaml
@@ -10,3 +10,235 @@ data:
 {{- else }}
   uuid: {{ uuidv4 | quote }}
 {{- end }}
+{{- if .Values.estap.all_can_control }}
+  STAP_CONFIG_ALL_CAN_CONTROL: {{ .Values.estap.all_can_control | quote }}
+{{- end }}
+{{- if .Values.estap.override_server_ip }}
+  STAP_CONFIG_TAP_TAP_IP: {{ .Values.estap.override_server_ip }}
+  STAP_CONFIG_TAP_PRIVATE_TAP_IP: "127.0.0.1"
+  STAP_CONFIG_TAP_FORCE_SERVER_IP: "1"
+{{- else }}
+  STAP_CONFIG_TAP_TAP_IP: "NULL"
+{{- end }}
+  STAP_CONFIG_PARTICIPATE_IN_LOAD_BALANCING: {{ include "estap-deploy.estap.participate_in_load_balancing" . | quote }}
+  STAP_CONFIG_PROXY_GROUP_MEMBER_COUNT: {{ include "estap-deploy.estap.replicas" . | quote }}
+{{- if .Values.estap.verify_guardium }}
+  STAP_CONFIG_SQLGUARD_CERT_CN: {{ .Values.estap.verify_guardium.cn }}
+  STAP_CONFIG_GUARDIUM_CA_PATH: {{ include "estap-deploy.estap.verify_guardium.ca_path" . }}
+{{- end }}
+  STAP_CONFIG_PROXY_DEBUG: {{ include "estap-deploy.estap.proxy.debug" . | quote }}
+  STAP_CONFIG_PROXY_NUM_WORKERS: {{ include "estap-deploy.estap.proxy.num_workers" . | quote }}
+  STAP_CONFIG_PROXY_PROXY_PROTOCOL: {{ include "estap-deploy.estap.proxy.proxy_protocol" . | quote }}
+  STAP_CONFIG_PROXY_DISCONNECT_ON_INVALID_CERTIFICATE: {{ include "estap-deploy.estap.proxy.disconnect_on_invalid_certificate" . | quote }}
+  STAP_CONFIG_PROXY_NOTIFY_ON_INVALID_CERTIFICATE: {{ include "estap-deploy.estap.proxy.notify_on_invalid_certificate" . | quote }}
+  STAP_CONFIG_PROXY_LISTEN_PORT: {{ include "estap-deploy.estap.proxy.listen_port" . | quote }}
+{{- if .Values.estap.proxy }}
+  {{- if .Values.estap.proxy.detect_ssl_within_x_packets }}
+  STAP_CONFIG_PROXY_DETECT_SSL_WITHIN_X_PACKETS: {{ .Values.estap.proxy.detect_ssl_within_x_packets | quote }}
+  {{- end }}
+{{- end }}
+{{- if .Values.global }}
+  {{- if .Values.global.secret }}
+    {{- if .Values.estap.proxy }}
+      {{- if .Values.estap.proxy.secret }}
+        {{- if .Values.estap.proxy.csr }}
+          {{- with .Values.estap.proxy.csr }}
+  STAP_CONFIG_PROXY_CSR_NAME: {{ .name }}
+            {{- if .country }}
+  STAP_CONFIG_PROXY_CSR_COUNTRY: {{ .country }}
+            {{- end }}
+            {{- if .province }}
+  STAP_CONFIG_PROXY_CSR_PROVINCE: {{ .province }}
+            {{- end }}
+            {{- if .city }}
+  STAP_CONFIG_PROXY_CSR_CITY: {{ .city }}
+            {{- end }}
+            {{- if .organization }}
+  STAP_CONFIG_PROXY_CSR_ORGANIZATION: {{ .organization }}
+            {{- end }}
+            {{- if .keylength }}
+  STAP_CONFIG_PROXY_CSR_KEYLENGTH: {{ .keylength | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- else }}
+  STAP_CONFIG_PROXY_PEM_PATH: "/tmp/metastore/estap.pem"
+      {{- end }}
+    {{- else }}
+  STAP_CONFIG_PROXY_PEM_PATH: "/tmp/metastore/estap.pem"
+    {{- end }}
+  {{- end }}
+{{- end }}
+  STAP_CONFIG_PROXY_DB_HOST: {{ .Values.estap.db.host | quote }}
+  STAP_CONFIG_DB_0_REAL_DB_PORT: {{ include "estap-deploy.estap.db.port" . | quote }}
+  STAP_CONFIG_DB_0_DB_TYPE: {{ .Values.estap.db.type | quote }}
+  STAP_CONFIG_SQLGUARD_0_SQLGUARD_IP: {{ .Values.estap.guardium.host | quote }}
+  STAP_CONFIG_SQLGUARD_0_PRIMARY: "1"
+{{- if .Values.estap.guardium.port }}
+  STAP_CONFIG_SQLGUARD_0_SQLGUARD_PORT: {{ .Values.estap.guardium.port | quote }}
+{{- end }}
+{{- if .Values.estap.guardium.connection_pool_size }}
+  STAP_CONFIG_SQLGUARD_0_CONNECTION_POOL_SIZE: {{ .Values.estap.guardium.connection_pool_size | quote }}
+{{- end }}
+{{- if .Values.estap.guardium.num_main_thread }}
+  STAP_CONFIG_SQLGUARD_0_NUM_MAIN_THREAD: {{ .Values.estap.guardium.num_main_thread | quote }}
+{{- end }}
+{{- if .Values.estap.guardium.secondaries }}
+  {{- if $.Values.estap.guardium.secondaries }}
+    {{- with $.Values.estap.guardium.secondaries }}
+      {{- if .s1 }}
+        {{- with .s1 }}
+          {{- if .host}}
+  STAP_CONFIG_SQLGUARD_1_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_1_PRIMARY: "2"
+            {{- if .port}}
+  STAP_CONFIG_SQLGUARD_1_SQLGUARD_PORT: {{ .port | quote }}
+            {{- end }}
+            {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_1_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+            {{- end }}
+            {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_1_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- if .s2 }}
+          {{- with .s2 }}
+            {{- if .host}}
+  STAP_CONFIG_SQLGUARD_2_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_2_PRIMARY: "3"
+              {{- if .port}}
+  STAP_CONFIG_SQLGUARD_2_SQLGUARD_PORT: {{ .port | quote }}
+              {{- end }}
+              {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_2_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+              {{- end }}
+              {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_2_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .s3 }}
+            {{- with .s3 }}
+              {{- if .host}}
+  STAP_CONFIG_SQLGUARD_3_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_3_PRIMARY: "4"
+                {{- if .port}}
+  STAP_CONFIG_SQLGUARD_3_SQLGUARD_PORT: {{ .port | quote }}
+                {{- end }}
+                {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_3_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+                {{- end }}
+                {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_3_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- if .s4 }}
+              {{- with .s4 }}
+                {{- if .host}}
+  STAP_CONFIG_SQLGUARD_4_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_4_PRIMARY: "5"
+                  {{- if .port}}
+  STAP_CONFIG_SQLGUARD_4_SQLGUARD_PORT: {{ .port | quote }}
+                  {{- end }}
+                  {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_4_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+                  {{- end }}
+                  {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_4_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+              {{- if .s5 }}
+                {{- with .s5 }}
+                  {{- if .host}}
+  STAP_CONFIG_SQLGUARD_5_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_5_PRIMARY: "6"
+                    {{- if .port}}
+  STAP_CONFIG_SQLGUARD_5_SQLGUARD_PORT: {{ .port | quote }}
+                    {{- end }}
+                    {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_5_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+                    {{- end }}
+                    {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_5_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
+                {{- if .s6 }}
+                  {{- with .s6 }}
+                    {{- if .host}}
+  STAP_CONFIG_SQLGUARD_6_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_6_PRIMARY: "7"
+                      {{- if .port}}
+  STAP_CONFIG_SQLGUARD_6_SQLGUARD_PORT: {{ .port | quote }}
+                      {{- end }}
+                      {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_6_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+                      {{- end }}
+                      {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_6_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+                      {{- end }}
+                    {{- end }}
+                  {{- end }}
+                  {{- if .s7 }}
+                    {{- with .s7 }}
+                      {{- if .host}}
+  STAP_CONFIG_SQLGUARD_7_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_7_PRIMARY: "8"
+                        {{- if .port}}
+  STAP_CONFIG_SQLGUARD_7_SQLGUARD_PORT: {{ .port | quote }}
+                        {{- end }}
+                        {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_7_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+                        {{- end }}
+                        {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_7_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+                        {{- end }}
+                      {{- end }}
+                    {{- end }}
+                    {{- if .s8 }}
+                      {{- with .s8 }}
+                        {{- if .host}}
+  STAP_CONFIG_SQLGUARD_8_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_8_PRIMARY: "9"
+                          {{- if .port}}
+  STAP_CONFIG_SQLGUARD_8_SQLGUARD_PORT: {{ .port | quote }}
+                          {{- end }}
+                          {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_8_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+                          {{- end }}
+                          {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_8_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+                          {{- end }}
+                        {{- end }}
+                      {{- end }}
+                      {{- if .s9 }}
+                        {{- with .s9 }}
+                          {{- if .host}}
+  STAP_CONFIG_SQLGUARD_9_SQLGUARD_IP: {{ .host | quote }}
+  STAP_CONFIG_SQLGUARD_9_PRIMARY: "10"
+                            {{- if .port}}
+  STAP_CONFIG_SQLGUARD_9_SQLGUARD_PORT: {{ .port | quote }}
+                            {{- end }}
+                            {{- if .connection_pool_size}}
+  STAP_CONFIG_SQLGUARD_9_CONNECTION_POOL_SIZE: {{ .connection_pool_size | quote }}
+                            {{- end }}
+                            {{- if .num_main_thread}}
+  STAP_CONFIG_SQLGUARD_9_NUM_MAIN_THREAD: {{ .num_main_thread | quote }}
+                            {{- end }}
+                          {{- end }}
+                        {{- end }}
+                      {{- end }}
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/estap/templates/estap-create-secret-writer-role.yaml
+++ b/charts/estap/templates/estap-create-secret-writer-role.yaml
@@ -2,27 +2,21 @@
 {{- if .Values }}
   {{- if .Values.global }}
     {{- if .Values.global.secret }}
-      {{- if (not (lookup "v1" "Secret" .Release.Namespace .Values.global.secret)) }}
-        {{- $serviceAccountName := .Values.estap.secretWriterServiceAccountName | default "estap-secret-writer" }}
-        {{- $serviceAccountRoleName := printf "%s-%s" $serviceAccountName "role" }}
-        {{- if not (lookup "rbac.authorization.k8s.io/v1" "Role" .Release.Namespace $serviceAccountRoleName ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "estap-deploy.global.secretWriterServiceAccountName" . }}-role
   labels:
-    component: {{ .Values.estap.name }}
-    app: {{ .Values.estap.name }}
+    component: {{ include "common.name" . }}
+    app: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-name: external-stap-inheritable-secret-account-role
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "watch", "list", "create", "update"]
-        {{- end }}
-      {{- end }}
+  verbs: ["get", "watch", "list", "create", "update", "patch"]
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/estap/templates/estap-create-secret-writer-rolebinding.yaml
+++ b/charts/estap/templates/estap-create-secret-writer-rolebinding.yaml
@@ -2,18 +2,14 @@
 {{- if .Values }}
   {{- if .Values.global }}
     {{- if .Values.global.secret }}
-      {{- if (not (lookup "v1" "Secret" .Release.Namespace .Values.global.secret)) }}
-        {{- $serviceAccountName := .Values.estap.secretWriterServiceAccountName | default "estap-secret-writer" }}
-        {{- $serviceAccountRoleBindingName := printf "%s-%s" $serviceAccountName "rolebinding" }}
-        {{- if not (lookup "rbac.authorization.k8s.io/v1" "RoleBinding" .Release.Namespace $serviceAccountRoleBindingName ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "estap-deploy.global.secretWriterServiceAccountName" . }}-rolebinding
   labels:
-    component: {{ .Values.estap.name }}
-    app: {{ .Values.estap.name }}
+    component: {{ include "common.name" . }}
+    app: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-name: external-stap-inheritable-secret-account-rolebinding
@@ -24,8 +20,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "estap-deploy.global.secretWriterServiceAccountName" . }}
-        {{- end }}
-      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/estap/templates/estap-create-secret-writer-serviceaccount.yaml
+++ b/charts/estap/templates/estap-create-secret-writer-serviceaccount.yaml
@@ -2,22 +2,17 @@
 {{- if .Values }}
   {{- if .Values.global }}
     {{- if .Values.global.secret }}
-      {{- if (not (lookup "v1" "Secret" .Release.Namespace .Values.global.secret)) }}
-        {{- $serviceAccountName := .Values.estap.secretWriterServiceAccountName | default "estap-secret-writer" }}
-        {{- if not (lookup "v1" "ServiceAccount" .Release.Namespace $serviceAccountName) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "estap-deploy.global.secretWriterServiceAccountName" . }}
   labels:
-    component: {{ .Values.estap.name }}
-    app: {{ .Values.estap.name }}
+    component: {{ include "common.name" . }}
+    app: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-name: external-stap-inheritable-secret-account
-        {{- end }}
-      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/estap/templates/estap-deploy.yaml
+++ b/charts/estap/templates/estap-deploy.yaml
@@ -5,21 +5,21 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "common.name" . }}
   labels:
-    component: {{ .Values.estap.name }}
-    app: {{ .Values.estap.name }}
+    component: {{ include "common.name" . }}
+    app: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
 spec:
   replicas: {{ include "estap-deploy.estap.replicas" . }}
   selector:
     matchLabels:
       component: {{ include "common.name" . }}
-      app: {{ .Values.estap.name }}
+      app: {{ include "common.name" . }}
       tier: backend
   template:
     metadata:
       labels:
         component: {{ include "common.name" . }}
-        app: {{ .Values.estap.name }}
+        app: {{ include "common.name" . }}
         tier: backend
         {{- include "common.labels" . | nindent 8 }}
     spec:
@@ -70,7 +70,7 @@ spec:
   {{- if .Values.global.secret }}
     {{- if or (not .Values.estap.proxy) (not .Values.estap.proxy.secret) }}
       initContainers:
-      - args: ["if [ -f /etc/estap-ssl/tls.crt ] && [ -f /etc/estap-ssl/tls.key ] ; then cat /etc/estap-ssl/tls.crt /etc/estap-ssl/tls.key > /tmp/metastore/estap.pem ; fi"]
+      - args: ["if [ -f /etc/estap-ssl/tls.crt ] && [ -f /etc/estap-ssl/tls.key ] ; then cat /etc/estap-ssl/tls.crt > /tmp/metastore/estap.pem ; echo >> /tmp/metastore/estap.pem ; cat /etc/estap-ssl/tls.key >> /tmp/metastore/estap.pem ; fi"]
         command:
         - /bin/sh
         - '-c'
@@ -112,317 +112,31 @@ spec:
           periodSeconds: {{ include "estap-deploy.estap.readinessProbe.periodSeconds" . }}
           failureThreshold: {{ include "estap-deploy.estap.readinessProbe.failureThreshold" . }}
           initialDelaySeconds: {{ include "estap-deploy.estap.readinessProbe.initialDelaySeconds" . }}
+        envFrom:
+          - configMapRef:
+              name: {{ include "common.name" . }}-configmap
         env:
           - name: container
             value: docker
-{{- if .Values.estap.override_server_ip }}
-          - name: STAP_CONFIG_TAP_TAP_IP
-            value: {{ .Values.estap.override_server_ip }}
-          - name: STAP_CONFIG_TAP_PRIVATE_TAP_IP
-            value: "NULL"
-          - name: STAP_CONFIG_TAP_FORCE_SERVER_IP
-            value: "1"
-{{- else }}
-          - name: STAP_CONFIG_TAP_TAP_IP
-            value: "NULL"
-{{- end }}
-          - name: STAP_CONFIG_PARTICIPATE_IN_LOAD_BALANCING
-            value: {{ include "estap-deploy.estap.participate_in_load_balancing" . | quote }}
-          - name: STAP_CONFIG_PROXY_GROUP_MEMBER_COUNT
-            value: {{ include "estap-deploy.estap.replicas" . | quote }}
           - name: STAP_CONFIG_PROXY_GROUP_UUID
             valueFrom:
               configMapKeyRef:
                 name: {{ include "common.name" . }}-configmap
                 key: uuid
-{{- if .Values.estap.verify_guardium }}
-          - name: STAP_CONFIG_SQLGUARD_CERT_CN
-            value: {{ .Values.estap.verify_guardium.cn }}
-          - name: STAP_CONFIG_GUARDIUM_CA_PATH
-            value: {{ include "estap-deploy.estap.verify_guardium.ca_path" . }}
-{{- end }}
-          - name: STAP_CONFIG_PROXY_DEBUG
-            value: {{ include "estap-deploy.estap.proxy.debug" . | quote }}
-          - name: STAP_CONFIG_PROXY_NUM_WORKERS
-            value: {{ include "estap-deploy.estap.proxy.num_workers" . | quote }}
-          - name: STAP_CONFIG_PROXY_PROXY_PROTOCOL
-            value: {{ include "estap-deploy.estap.proxy.proxy_protocol" . | quote }}
-          - name: STAP_CONFIG_PROXY_DISCONNECT_ON_INVALID_CERTIFICATE
-            value: {{ include "estap-deploy.estap.proxy.disconnect_on_invalid_certificate" . | quote }}
-          - name: STAP_CONFIG_PROXY_NOTIFY_ON_INVALID_CERTIFICATE
-            value: {{ include "estap-deploy.estap.proxy.notify_on_invalid_certificate" . | quote }}
-          - name: STAP_CONFIG_PROXY_LISTEN_PORT
-            value: {{ include "estap-deploy.estap.proxy.listen_port" . | quote }}
-{{- if .Values.global }}
-  {{- if .Values.global.secret }}
-    {{- if .Values.estap.proxy }}
-      {{- if .Values.estap.proxy.secret }}
+{{- if .Values.estap.proxy }}
+  {{- if .Values.estap.proxy.secret }}
           - name: STAP_CONFIG_PROXY_SECRET
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.global.secret }}
                 key: {{ .Values.estap.proxy.secret }}
-        {{- if .Values.estap.proxy.csr }}
-          {{- with .Values.estap.proxy.csr }}
-          - name: STAP_CONFIG_PROXY_CSR_NAME
-            value: {{ .name }}
-            {{- if .country }}
-          - name: STAP_CONFIG_PROXY_CSR_COUNTRY
-            value: {{ .country }}
-            {{- end }}
-            {{- if .province }}
-          - name: STAP_CONFIG_PROXY_CSR_PROVINCE
-            value: {{ .province }}
-            {{- end }}
-            {{- if .city }}
-          - name: STAP_CONFIG_PROXY_CSR_CITY
-            value: {{ .city }}
-            {{- end }}
-            {{- if .organization }}
-          - name: STAP_CONFIG_PROXY_CSR_ORGANIZATION
-            value: {{ .organization }}
-            {{- end }}
-            {{- if .keylength }}
-          - name: STAP_CONFIG_PROXY_CSR_KEYLENGTH
-            value: {{ .keylength | quote }}
-            {{- end }}
-          {{- end }}
-        {{- end }}
-      {{- else }}
+  {{- else }}
           - name: STAP_CONFIG_PROXY_PEM_PATH
             value: /tmp/metastore/estap.pem
-      {{- end }}
-    {{- else }}
-        - name: STAP_CONFIG_PROXY_PEM_PATH
-          value: /tmp/metastore/estap.pem
-    {{- end }}
   {{- end }}
-{{- end }}
-          - name: STAP_CONFIG_PROXY_DB_HOST
-            value: {{ .Values.estap.db.host | quote }}
-          - name: STAP_CONFIG_DB_0_REAL_DB_PORT
-            value: {{ include "estap-deploy.estap.db.port" . | quote }}
-          - name: STAP_CONFIG_DB_0_DB_TYPE
-            value: {{ .Values.estap.db.type | quote }}
-          - name: STAP_CONFIG_SQLGUARD_0_SQLGUARD_IP
-            value: {{ .Values.estap.guardium.host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_0_PRIMARY
-            value: "1"
-{{- if .Values.estap.guardium.port }}
-          - name: STAP_CONFIG_SQLGUARD_0_SQLGUARD_PORT
-            value: {{ .Values.estap.guardium.port | quote }}
-{{- end }}
-{{- if .Values.estap.guardium.connection_pool_size }}
-          - name: STAP_CONFIG_SQLGUARD_0_CONNECTION_POOL_SIZE
-            value: {{ .Values.estap.guardium.connection_pool_size | quote }}
-{{- end }}
-{{- if .Values.estap.guardium.num_main_thread }}
-          - name: STAP_CONFIG_SQLGUARD_0_NUM_MAIN_THREAD
-            value: {{ .Values.estap.guardium.num_main_thread | quote }}
-{{- end }}
-{{- if .Values.estap.guardium.secondaries }}
-  {{- if $.Values.estap.guardium.secondaries }}
-    {{- with $.Values.estap.guardium.secondaries }}
-      {{- if .s1 }}
-        {{- with .s1 }}
-          {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_1_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_1_PRIMARY
-            value: "2"
-            {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_1_SQLGUARD_PORT
-            value: {{ .port | quote }}
-            {{- end }}
-            {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_1_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-            {{- end }}
-            {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_1_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-            {{- end }}
-          {{- end }}
-        {{- end }}
-        {{- if .s2 }}
-          {{- with .s2 }}
-            {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_2_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_2_PRIMARY
-            value: "3"
-              {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_2_SQLGUARD_PORT
-            value: {{ .port | quote }}
-              {{- end }}
-              {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_2_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-              {{- end }}
-              {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_2_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
-          {{- if .s3 }}
-            {{- with .s3 }}
-              {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_3_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_3_PRIMARY
-            value: "4"
-                {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_3_SQLGUARD_PORT
-            value: {{ .port | quote }}
-                {{- end }}
-                {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_3_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-                {{- end }}
-                {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_3_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-                {{- end }}
-              {{- end }}
-            {{- end }}
-            {{- if .s4 }}
-              {{- with .s4 }}
-                {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_4_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_4_PRIMARY
-            value: "5"
-                  {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_4_SQLGUARD_PORT
-            value: {{ .port | quote }}
-                  {{- end }}
-                  {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_4_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-                  {{- end }}
-                  {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_4_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-                  {{- end }}
-                {{- end }}
-              {{- end }}
-              {{- if .s5 }}
-                {{- with .s5 }}
-                  {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_5_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_5_PRIMARY
-            value: "6"
-                    {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_5_SQLGUARD_PORT
-            value: {{ .port | quote }}
-                    {{- end }}
-                    {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_5_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-                    {{- end }}
-                    {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_5_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-                    {{- end }}
-                  {{- end }}
-                {{- end }}
-                {{- if .s6 }}
-                  {{- with .s6 }}
-                    {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_6_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_6_PRIMARY
-            value: "7"
-                      {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_6_SQLGUARD_PORT
-            value: {{ .port | quote }}
-                      {{- end }}
-                      {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_6_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-                      {{- end }}
-                      {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_6_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-                      {{- end }}
-                    {{- end }}
-                  {{- end }}
-                  {{- if .s7 }}
-                    {{- with .s7 }}
-                      {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_7_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_7_PRIMARY
-            value: "8"
-                        {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_7_SQLGUARD_PORT
-            value: {{ .port | quote }}
-                        {{- end }}
-                        {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_7_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-                        {{- end }}
-                        {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_7_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-                        {{- end }}
-                      {{- end }}
-                    {{- end }}
-                    {{- if .s8 }}
-                      {{- with .s8 }}
-                        {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_8_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_8_PRIMARY
-            value: "9"
-                          {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_8_SQLGUARD_PORT
-            value: {{ .port | quote }}
-                          {{- end }}
-                          {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_8_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-                          {{- end }}
-                          {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_8_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-                          {{- end }}
-                        {{- end }}
-                      {{- end }}
-                      {{- if .s9 }}
-                        {{- with .s9 }}
-                          {{- if .host}}
-          - name: STAP_CONFIG_SQLGUARD_9_SQLGUARD_IP
-            value: {{ .host | quote }}
-          - name: STAP_CONFIG_SQLGUARD_9_PRIMARY
-            value: "10"
-                            {{- if .port}}
-          - name: STAP_CONFIG_SQLGUARD_9_SQLGUARD_PORT
-            value: {{ .port | quote }}
-                            {{- end }}
-                            {{- if .connection_pool_size}}
-          - name: STAP_CONFIG_SQLGUARD_9_CONNECTION_POOL_SIZE
-            value: {{ .connection_pool_size | quote }}
-                            {{- end }}
-                            {{- if .num_main_thread}}
-          - name: STAP_CONFIG_SQLGUARD_9_NUM_MAIN_THREAD
-            value: {{ .num_main_thread | quote }}
-                            {{- end }}
-                          {{- end }}
-                        {{- end }}
-                      {{- end }}
-                    {{- end }}
-                  {{- end }}
-                {{- end }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
+{{- else }}
+          - name: STAP_CONFIG_PROXY_PEM_PATH
+            value: /tmp/metastore/estap.pem
 {{- end }}
         ports:
           - containerPort: 8080
@@ -449,6 +163,9 @@ spec:
           - mountPath: /var/run/gp
             name: ephemeral
             subPath: run_gp
+          - mountPath: /var/support/gp
+            name: ephemeral
+            subPath: support_gp
           - mountPath: /usr/local/guardium
             name: ephemeral
             subPath: usr/local/guardium

--- a/charts/estap/templates/estap-networkpolicy.yaml
+++ b/charts/estap/templates/estap-networkpolicy.yaml
@@ -1,0 +1,24 @@
+# vim: ts=2:sw=2:et
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "common.name" . }}-networkpolicy
+  labels:
+    component: {{ include "common.name" . }}
+    app: {{ include "common.name" . }}
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  ingress:
+  - ports:
+    - port: {{ include "estap-deploy.estap.proxy.listen_port" . }}
+      protocol: TCP
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      component: {{ include "common.name" . }}
+      tier: backend
+  policyTypes:
+  - Ingress
+  - Egress

--- a/charts/estap/templates/estap-service.yaml
+++ b/charts/estap/templates/estap-service.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ include "common.name" . }}-lb
   labels:
     serviceType : LoadBalancer
-    app: {{ .Values.estap.name }}
-    component: {{ .Values.estap.name }}
+    app: {{ include "common.name" . }}
+    component: {{ include "common.name" . }}
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -15,7 +15,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/part-of: {{ .Values.estap.name }}
+    app.kubernetes.io/part-of: {{ include "common.name" . }}
 {{- if .Values.estap.service }}
   {{- if .Values.estap.service.annotations }}
   annotations:

--- a/charts/estap/templates/post-install.yaml
+++ b/charts/estap/templates/post-install.yaml
@@ -1,13 +1,10 @@
 # vim: ts=2:sw=2:et
-{{- if .Values }}
-  {{- if .Values.global }}
-    {{- if .Values.global.secret }}
-      {{- if (not (lookup "v1" "Secret" .Release.Namespace .Values.global.secret)) }}
+{{- if .Values.updateSecret }}
 kind: Job
 apiVersion: batch/v1
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "common.name" . }}-create-secret-job
+  name: {{ include "common.name" . }}-update-secret-job-{{ .Release.Revision }}
   labels:
     component: {{ include "common.name" . }}
     app: {{ include "common.name" . }}
@@ -18,9 +15,12 @@ spec:
     template:
       metadata:
         labels:
-          run: {{ include "common.name" . }}-create-secret-job
+          run: {{ include "common.name" . }}-update-secret-job
       spec:
         volumes:
+        - secret:
+            secretName: {{ .Values.global.secret }}
+          name: secret-volume
         - emptyDir: {}
           name: metastore-volume
         serviceAccountName: {{ include "estap-deploy.global.secretWriterServiceAccountName" . }}
@@ -31,29 +31,30 @@ spec:
       {{- end }}
     {{- end }}
         initContainers:
-        - name: estap-create-secret-job-cert-gen
+        - name: estap-update-secret-job-cert-gen
           volumeMounts:
+          - mountPath: /tmp/secret
+            name: secret-volume
           - mountPath: /tmp/metastore
             name: metastore-volume
           image: {{ include "estap-deploy.estap.registryImageTag" . }}
-          args: ['gpctl genca > /tmp/metastore/ca.pem && gpctl gen_csr && mv /var/log/gp/key.tmp.pem /tmp/metastore/tls.key && gpctl -A/tmp/metastore/ca.pem -R/var/log/gp/csr.tmp.pem sign_csr > /tmp/metastore/tls.crt && rm -f /var/log/gp/csr.tmp.pem' ]
+          args: ['gpctl gen_csr && mv /var/log/gp/key.tmp.pem /tmp/metastore/tls.key && gpctl -A/tmp/secret/ca.pem -R/var/log/gp/csr.tmp.pem sign_csr > /tmp/metastore/tls.crt && rm -f /var/log/gp/csr.tmp.pem' ]
           command:
           - /bin/sh
           - '-c'
           imagePullPolicy: {{ include "estap-deploy.estap.imagePullPolicy" . }}
         containers:
-        - name: estap-create-secret-job
+        - name: estap-update-secret-job
           volumeMounts:
+          - mountPath: /tmp/secret
+            name: secret-volume
           - mountPath: /tmp/metastore
             name: metastore-volume
           image: {{ include "estap-deploy.estap.registryImageTag" . }}
-          args: ["env && kubectl create secret generic {{ .Values.global.secret }} --from-file=ca.pem=/tmp/metastore/ca.pem --from-file=tls.key=/tmp/metastore/tls.key --from-file=tls.crt=/tmp/metastore/tls.crt"]
+          args: ["env && kubectl create secret generic {{ .Values.global.secret }} --save-config --dry-run --from-file=ca.pem=/tmp/secret/ca.pem --from-file=tls.key=/tmp/metastore/tls.key --from-file=tls.crt=/tmp/metastore/tls.crt -o yaml | kubectl apply -f -"]
           command:
           - /bin/sh
           - '-c'
           imagePullPolicy: {{ include "estap-deploy.estap.imagePullPolicy" . }}
         restartPolicy: OnFailure
-      {{- end }}
-    {{- end }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
… for the load balancing service, fixes the issue with SA, roles, and roleBindings going missing during an upgrade, switches to using a configmap to store the e-stap configuration, and allows regenerating the certificates during an upgrade.