### PR TITLE
GRD-120316:  Update charts to allow for setting the service type expl…

### DIFF
--- a/charts/estap/templates/_helpers.tpl
+++ b/charts/estap/templates/_helpers.tpl
@@ -158,3 +158,7 @@ seccompProfile:
 {{- define "estap-deploy.global.secretWriterServiceAccountName" }}
 {{- .Values.global.secretWriterServiceAccountName | default "estap-secret-writer" }}
 {{- end }}
+
+{{- define "estap-svc.typeAuto" }}
+{{- if .Values.estap.route }} {{- if .Values.estap.route.name }} ClusterIP {{- else }} {{- if .Values.estap.ingress }} NodePort {{- else }} LoadBalancer {{- end }} {{- end }} {{- else }} {{- if .Values.estap.ingress }} NodePort {{- else }} LoadBalancer {{- end }} {{- end }}
+{{- end }}

--- a/charts/estap/templates/estap-service.yaml
+++ b/charts/estap/templates/estap-service.yaml
@@ -25,22 +25,14 @@ metadata:
   {{- end }}
 {{- end }}
 spec:
-{{- if .Values.estap.route }}
-  {{- if .Values.estap.route.name }}
-  type: ClusterIP
+{{- if .Values.estap.service }}
+  {{- if .Values.estap.service.type }}
+  type: {{ .Values.estap.service.type }}
   {{- else }}
-  {{- if .Values.estap.ingress }}
-  type: NodePort
-  {{- else }}
-  type: LoadBalancer
-  {{- end }}
+  type: {{ include "estap-svc.typeAuto" . }}
   {{- end }}
 {{- else }}
-  {{- if .Values.estap.ingress }}
-  type: NodePort
-  {{- else }}
-  type: LoadBalancer
-  {{- end }}
+  type: {{ include "estap-svc.typeAuto" . }}
 {{- end }}
   ports:
   - protocol: TCP

--- a/charts/overrides_example.yaml
+++ b/charts/overrides_example.yaml
@@ -102,6 +102,10 @@ estap:
       #haproxy.router.openshift.io/timeout: 90s
   
   #service:
+    # Type of the service to use, one of LoadBalancer, NodePort, ClusterIP
+    # If parameter is not specified, then it will be ClusterIP if route.name
+    # is specified, NodePort if ingress is specified, or LoadBalancer
+    #type: LoadBalancer
     # Optional, annotations to add to the service.  Typically used
     # to link with Kubernetes provider's load balancer  
     # Annotations need to be string encoded.


### PR DESCRIPTION
…icitly.  This will help with deployments that use a front-side load balancer such as HAProxy to maintain a failover route around the deployment.  When the front-side load balancer is deployed into kubernetes, the service only needs to be ClusterIP, no need to attach to any cloud provider's external load balancer or to open node ports